### PR TITLE
Rewrite to be easier to change values + compact mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,12 @@ import (
 var version = "development"
 
 func main() {
+	var showAMPMFlag bool
+	flag.BoolVar(&showAMPMFlag, "show-am-pm", false, "visualize AM/PM")
+
+	var compactFlag bool
+	flag.BoolVar(&compactFlag, "compact", false, "compact format")
+
 	var offColorFlag string
 	flag.StringVar(&offColorFlag, "off-color", "black", "color for disabled letters")
 
@@ -25,6 +31,7 @@ func main() {
 
 	var versionFlag bool
 	flag.BoolVar(&versionFlag, "version", false, "print version and exit")
+
 
 	flag.Parse()
 
@@ -39,6 +46,8 @@ func main() {
 	game.Screen().AddEntity(qlock.New(
 		color(onColorFlag),
 		color(offColorFlag),
+		compactFlag,
+		showAMPMFlag,
 	))
 	game.Start()
 }

--- a/qlock/board.go
+++ b/qlock/board.go
@@ -4,100 +4,63 @@
 
 package qlock
 
-type entry struct {
-	x    int
-	y    int
-	text string
-}
+const (
+	it     = "IT"
+	is     = "IS"
+	a      = "A"
+	to     = "TO"
+	past   = "PAST"
+	oClock = "O'CLOCK"
+
+	quarter = "QUARTER"
+	twenty  = "TWENTY"
+	half    = "HALF"
+	am      = "AM"
+	pm      = "PM"
+
+	one    = "ONE"
+	two    = "TWO"
+	three  = "THREE"
+	four   = "FOUR"
+	five   = "FIVE"
+	six    = "SIX"
+	seven  = "SEVEN"
+	eight  = "EIGHT"
+	nine   = "NINE"
+	ten    = "TEN"
+	eleven = "ELEVEN"
+	twelve = "TWELVE"
+
+	dot = "●"
+	f1  = "L"
+	f2  = "AS"
+	f3  = "C"
+	f4  = "DC"
+	f5  = "X"
+	f6  = "S"
+	f7  = "F"
+	f8  = "ERU"
+	f9  = "SE"
+
+	width         = 40
+	height        = 20
+	compactWidth  = 20
+	compactHeight = 11
+)
 
 var (
-	width  = 44
-	height = 20
-
-	it     = entry{2, 1, "I   T"}
-	is     = entry{14, 1, "I   S"}
-	a      = entry{2, 3, "A"}
-	to     = entry{38, 7, "T   O"}
-	past   = entry{2, 9, "P   A   S   T"}
-	oclock = entry{22, 19, "O'  C   L   O   C   K"}
-
-	fiveOff = entry{26, 5, "F   I   V   E"}
-	tenOff  = entry{22, 7, "T   E   N"}
-	quarter = entry{10, 3, "Q   U   A   R   T   E   R"}
-	twenty  = entry{2, 5, "T   W   E   N   T   Y"}
-	half    = entry{2, 7, "H   A   L   F"}
-
-	one        = entry{2, 11, "O   N   E"}
-	two        = entry{34, 13, "T   W   O"}
-	three      = entry{26, 11, "T   H   R   E   E"}
-	four       = entry{2, 13, "F   O   U   R"}
-	fiveSecond = entry{18, 13, "F   I   V   E"}
-	six        = entry{14, 11, "S   I   X"}
-	seven      = entry{2, 17, "S   E   V   E   N"}
-	eight      = entry{2, 15, "E   I   G   H   T"}
-	nine       = entry{30, 9, "N   I   N   E"}
-	tenSecond  = entry{2, 19, "T   E   N"}
-	eleven     = entry{22, 15, "E   L   E   V   E   N"}
-	twelve     = entry{22, 17, "T   W   E   L   V   E"}
-
-	dotOne   = entry{0, 0, "●"}
-	dotTwo   = entry{44, 0, "●"}
-	dotThree = entry{44, 20, "●"}
-	dotFour  = entry{0, 20, "●"}
-
-	all = map[entry]struct{}{
-		it:         {},
-		is:         {},
-		a:          {},
-		to:         {},
-		quarter:    {},
-		half:       {},
-		oclock:     {},
-		past:       {},
-		one:        {},
-		two:        {},
-		three:      {},
-		four:       {},
-		fiveOff:    {},
-		fiveSecond: {},
-		six:        {},
-		seven:      {},
-		eight:      {},
-		nine:       {},
-		tenOff:     {},
-		tenSecond:  {},
-		eleven:     {},
-		twelve:     {},
-		twenty:     {},
-
-		dotOne:   {},
-		dotTwo:   {},
-		dotThree: {},
-		dotFour:  {},
-
-		{10, 1, "L"}:                     {},
-		{22, 1, "A   S   A   M   P   M"}: {},
-		{6, 3, "C"}:                      {},
-		{38, 3, "D   C"}:                 {},
-		{42, 5, "X"}:                     {},
-		{18, 7, "S"}:                     {},
-		{34, 7, "F"}:                     {},
-		{18, 9, "E   R   U"}:             {},
-		{14, 19, "S   E"}:                {},
-	}
-
-	hours = []entry{
+	hours = []string{
 		twelve,
 		one,
 		two,
 		three,
 		four,
-		fiveSecond,
+		five,
 		six,
 		seven,
 		eight,
 		nine,
-		tenSecond,
+		ten,
 		eleven,
 	}
 )

--- a/qlock/rules.go
+++ b/qlock/rules.go
@@ -4,58 +4,96 @@
 
 package qlock
 
-func entries(hour int, minute int) map[entry]struct{} {
-	items := []entry{
-		it, is,
+type entry struct {
+	Text   string
+	Active bool
+}
+
+func e(text string, active bool) entry {
+	return entry{Text: text, Active: active}
+}
+
+func activate(board [][]entry, row, index int) {
+	board[row][index].Active = true
+}
+
+func quickAbs(value int) int {
+	return value * ((value*2 + 1) % 2)
+}
+
+func entries(hour int, minute int, ampm bool) [][]entry {
+	board := [][]entry{
+		{e(it, true), e(f1, false), e(is, true), e(f2, false), e(am, false), e(pm, false)},
+		{e(a, false), e(f3, false), e(quarter, false), e(f4, false)},
+		{e(twenty, false), e(five, false), e(f5, false)},
+		{e(half, false), e(f6, false), e(ten, false), e(f7, false), e(to, false)},
+		{e(past, false), e(f8, false), e(nine, false)},
+		{e(one, false), e(six, false), e(three, false)},
+		{e(four, false), e(five, false), e(two, false)},
+		{e(eight, false), e(eleven, false)},
+		{e(seven, false), e(twelve, false)},
+		{e(ten, false), e(f9, false), e(oClock, false)},
 	}
 
-	switch minute - minute%5 {
-	case 55:
-		items = append(items, fiveOff, to)
-	case 50:
-		items = append(items, tenOff, to)
-	case 45:
-		items = append(items, a, quarter, to)
-	case 40:
-		items = append(items, twenty, to)
-	case 35:
-		items = append(items, twenty, fiveOff, to)
-	case 30:
-		items = append(items, half, past)
+	minSection := minute - minute%5
+
+	if ampm {
+		if hour < 12 {
+			activate(board, 0, 4)
+		} else {
+			activate(board, 0, 5)
+		}
+	}
+
+	if minSection > 30 {
+		// Set: to.
+		activate(board, 3, 4)
+	} else if minSection == 0 {
+		activate(board, 9, 2)
+	} else {
+		// Set: past.
+		activate(board, 4, 0)
+	}
+
+	switch quickAbs(minSection - 30) {
 	case 25:
-		items = append(items, twenty, fiveOff, past)
+		activate(board, 2, 1)
 	case 20:
-		items = append(items, twenty, past)
+		activate(board, 3, 2)
 	case 15:
-		items = append(items, a, quarter, past)
+		activate(board, 1, 0)
+		activate(board, 1, 2)
 	case 10:
-		items = append(items, tenOff, past)
+		activate(board, 2, 0)
 	case 5:
-		items = append(items, fiveOff, past)
+		activate(board, 2, 0)
+		activate(board, 2, 1)
 	case 0:
-		items = append(items, oclock)
+		if minSection == 30 {
+			activate(board, 3, 0)
+		}
 	}
 
-	switch minute % 5 {
-	case 1:
-		items = append(items, dotOne)
-	case 2:
-		items = append(items, dotOne, dotTwo)
-	case 3:
-		items = append(items, dotOne, dotTwo, dotThree)
-	case 4:
-		items = append(items, dotOne, dotTwo, dotThree, dotFour)
-	}
+	var target string
 
 	if minute >= 35 {
-		items = append(items, hours[(hour+1)%12])
+		target = hours[(hour+1)%12]
 	} else {
-		items = append(items, hours[hour%12])
+		target = hours[hour%12]
 	}
 
-	set := make(map[entry]struct{}, len(items))
-	for _, item := range items {
-		set[item] = struct{}{}
+outer:
+	for idx := 5; idx < len(board); idx++ {
+		for jdx := 0; jdx < len(board[idx]); jdx++ {
+			if board[idx][jdx].Text == target {
+				board[idx][jdx].Active = true
+
+				break outer
+			}
+		}
 	}
-	return set
+
+	_ = target
+
+	return board
 }


### PR DESCRIPTION
First I tried to add a compact mode because it was too big for me, so started to hack around to make it smaller, but it was way harder than I thought with all the `(x,y)` coordinates, so I started to refactor to use normal strings without spacing and build up the board piece by piece. So that's how I ended up with this change-set.

At the same time I moved all 4 dots to the top row because that way it's much easier for my eyes and easier to see how many of them are active (opposed to check corners).

At this point I do not expect it can land in the repo from a PR as it has a lot of changes, even on how it looks by default, but I'll give it a shot ;) Below two screenshots how it looks like now with compact and normal view. Default is the original size.


Compact view (Flags: `-on-color=red+bold -off-color=black+bold -compact`):
![image](https://user-images.githubusercontent.com/183191/115738395-4e0b1f00-a38d-11eb-81d7-89756a1eb9b4.png)


The original size with the dot changes: Compact view (Flags: `-on-color=red+bold -off-color=black+bold`):
![image](https://user-images.githubusercontent.com/183191/115738294-37fd5e80-a38d-11eb-82a3-be10b3a86e97.png)

Note: I love this clock, but it was always space consuming in my tmux.